### PR TITLE
support specifying custom x-org-id via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ docker run -p 80:80 -e GRAPHITE_CLUSTER_SERVERS=metrictank:6060 raintank/graphit
 Additional environment variables can be set to adjust performance.
 
 ### metrictank
-* SINGLE_TENANT: if set will configure the graphite installation to pass  "x-org-id: 1" header to metrictank. If not set, metrictank must be configured with multi_tenant=false
-  or all requests to graphite must include a "x-org-id" header with a valid orgId.
+* SINGLE_TENANT: 
+  - if set to a number, will configure the graphite installation to pass that x-org-id to metrictank.
+  - if set to a any non-empty string, will configure the graphite installation to pass  "x-org-id: 1" header to metrictank.
+  - if not set, all requests to graphite must include a "x-org-id" header with a valid orgId or metrictank must be configured with multi_tenant=false
+    otherwise authentication will fail.
 
 ### MOD_WSGI
 * WSGI_PROCESSES: (2) the number of WSGI daemon processes that should be started

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,12 @@ export GRAPHITE_WSGI_VIRTUAL_MEMORY_LIMIT=${GRAPHITE_WSGI_VIRTUAL_MEMORY_LIMIT:-
 export GRAPHITE_WSGI_MAX_REQUESTS=${GRAPHITE_WSGI_MAX_REQUESTS:-1000}
 
 ARGS="-DFOREGROUND"
-if [ ! -z "$SINGLE_TENANT" ]; then
+
+if [ -n "$SINGLE_TENANT" ]; then
+
+	# legacy values like "yes", "TRUE" set to 1
+	[[ $SINGLE_TENANT =~ ^[0-9]+$ ]] || export SINGLE_TENANT=1
+
 	ARGS="$ARGS -DSingleTenant"
 fi
 

--- a/vhost.conf
+++ b/vhost.conf
@@ -16,7 +16,7 @@ WSGISocketPrefix /opt/graphite/run/wsgi
 
         <IfDefine SingleTenant>
             RequestHeader unset X-Org-Id
-            RequestHeader append X-Org-Id "1"
+            RequestHeader append X-Org-Id "${SINGLE_TENANT}"
         </IfDefine>
 
         WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi


### PR DESCRIPTION
this way, you can more easily look at data for specific orgs while
testing; by running a graphite pods for each org