### PR TITLE
fix stderr reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Additional environment variables can be set to adjust performance.
 * GRAPHITE_LOG_ROTATION_COUNT: (1) number of logs to keep
 * GRAPHITE_LOG_RENDERING_PERFORMANCE: (true) log performance information
 * GRAPHITE_LOG_CACHE_PERFORMANCE: (true) log cache performance information
+* GRAPHITE_LOG_FILE_INFO: (info.log), set to "-" for stdout/stderr
+* GRAPHITE_LOG_FILE_EXCEPTION: (exception.log), set to "-" for stdout/stderr
+* GRAPHITE_LOG_FILE_CACHE: (cache.log), set to "-" for stdout/stderr
+* GRAPHITE_LOG_FILE_RENDERING: (rendering.log), set to "-" for stdout/stderr
 * GRAPHITE_DEBUG: (false) Enable full debug page display on exceptions (Internal Server Error pages)
 * GRAPHITE_DEFAULT_CACHE_DURATION: (0) Duration to cache metric data and graphs
 * GRAPHITE_USE_WORKER_POOL: (true) Creates a pool of worker threads to which tasks can be dispatched

--- a/vhost.conf
+++ b/vhost.conf
@@ -1,3 +1,5 @@
+### wsgi is dumping errors back to apache so we need to override apache main config here
+ErrorLog /dev/stderr
 WSGISocketPrefix /opt/graphite/run/wsgi
 <VirtualHost *:80>
         ServerName graphite


### PR DESCRIPTION
Ive tested this with an invalid datasource but nothing more.

Here is the output from docker logs compared to whats reported in issue #9 

```[Thu Jun 14 01:02:12.360503 2018] [wsgi:error] [pid 15:tid 139760100136704] fetch for [u'badquery']: Error requesting http://localhost:6060/render/?format=pickle&local=1&noCache=1&from=1528851732&until=1528938132&target=badquery&now=1528938132: HTTPConnectionPool(host='localhost', port=6060): Max retries exceeded with url: /render/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f1c6c1061d0>: Failed to establish a new connection: [Errno 111] Connection refused',)): Traceback (most recent call last):
[Thu Jun 14 01:02:12.360508 2018] [wsgi:error] [pid 15:tid 139760100136704]
[Thu Jun 14 01:02:12.360512 2018] [wsgi:error] [pid 15:tid 139760100136704]   File "/opt/graphite/webapp/graphite/worker_pool/pool.py", line 43, in run
[Thu Jun 14 01:02:12.360515 2018] [wsgi:error] [pid 15:tid 139760100136704]     self.result = self.func(*self.args, **self.kwargs)
[Thu Jun 14 01:02:12.360519 2018] [wsgi:error] [pid 15:tid 139760100136704]
[Thu Jun 14 01:02:12.360522 2018] [wsgi:error] [pid 15:tid 139760100136704]   File "/opt/graphite/webapp/graphite/finders/remote.py", line 153, in fetch
[Thu Jun 14 01:02:12.360525 2018] [wsgi:error] [pid 15:tid 139760100136704]     return reader.fetch_multi(start_time, end_time, now, requestContext)
[Thu Jun 14 01:02:12.360543 2018] [wsgi:error] [pid 15:tid 139760100136704]
[Thu Jun 14 01:02:12.360547 2018] [wsgi:error] [pid 15:tid 139760100136704]   File "/opt/graphite/webapp/graphite/readers/remote.py", line 64, in fetch_multi
[Thu Jun 14 01:02:12.360552 2018] [wsgi:error] [pid 15:tid 139760100136704]     timeout=settings.FETCH_TIMEOUT,
[Thu Jun 14 01:02:12.360555 2018] [wsgi:error] [pid 15:tid 139760100136704]
[Thu Jun 14 01:02:12.360558 2018] [wsgi:error] [pid 15:tid 139760100136704]   File "/opt/graphite/webapp/graphite/finders/remote.py", line 266, in request
[Thu Jun 14 01:02:12.360560 2018] [wsgi:error] [pid 15:tid 139760100136704]     raise Exception("Error requesting %s: %s" % (url_full, err))
[Thu Jun 14 01:02:12.360577 2018] [wsgi:error] [pid 15:tid 139760100136704]
[Thu Jun 14 01:02:12.360581 2018] [wsgi:error] [pid 15:tid 139760100136704] Exception: Error requesting http://localhost:6060/render/?format=pickle&local=1&noCache=1&from=1528851732&until=1528938132&target=badquery&now=1528938132: HTTPConnectionPool(host='localhost', port=6060): Max retries exceeded with url: /render/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f1c6c1061d0>: Failed to establish a new connection: [Errno 111] Connection refused',))
[Thu Jun 14 01:02:12.360594 2018] [wsgi:error] [pid 15:tid 139760100136704]
172.17.0.1 - - [14/Jun/2018:01:02:12 +0000] "GET /render?format=json&target=badquery HTTP/1.1" 500 3788```