### PR TITLE
use metrictank as authorative backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Additional environment variables can be set to adjust performance.
 * GRAPHITE_POOL_WORKERS: (1) A baseline number of workers that should always be created
 * GRAPHITE_REMOTE_FIND_TIMEOUT: (30) Timeout for metric find requests
 * GRAPHITE_REMOTE_FETCH_TIMEOUT: (60) Timeout to fetch series data
-* GRAPHITE_REMOTE_RETRY_DELAY: (10) Time before retrying a failed remote webapp
+* GRAPHITE_REMOTE_RETRY_DELAY: (0) Time before retrying a failed remote webapp. Should keep this 0 to enforce metrictank remains the source of truth even in light of cluster failures.
 * GRAPHITE_MAX_FETCH_RETRIES: (2) Number of retries for a specific remote data fetch
 * GRAPHITE_FIND_CACHE_DURATION: (0) Time to cache remote metric find results
 * GRAPHITE_STATSD_HOST: ("") If set, django_statsd.middleware.GraphiteRequestTimingMiddleware and django_statsd.middleware.GraphiteMiddleware will be enabled.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Additional environment variables can be set to adjust performance.
 * GRAPHITE_POOL_WORKERS: (1) A baseline number of workers that should always be created
 * GRAPHITE_REMOTE_FIND_TIMEOUT: (30) Timeout for metric find requests
 * GRAPHITE_REMOTE_FETCH_TIMEOUT: (60) Timeout to fetch series data
-* GRAPHITE_REMOTE_RETRY_DELAY: (0) Time before retrying a failed remote webapp. Should keep this 0 to enforce metrictank remains the source of truth even in light of cluster failures.
 * GRAPHITE_MAX_FETCH_RETRIES: (2) Number of retries for a specific remote data fetch
 * GRAPHITE_FIND_CACHE_DURATION: (0) Time to cache remote metric find results
 * GRAPHITE_STATSD_HOST: ("") If set, django_statsd.middleware.GraphiteRequestTimingMiddleware and django_statsd.middleware.GraphiteMiddleware will be enabled.

--- a/local_settings.py
+++ b/local_settings.py
@@ -121,7 +121,7 @@ POOL_WORKERS = int(os.environ.get('GRAPHITE_POOL_WORKERS', '1'))
 # These are timeout values (in seconds) for requests to remote webapps
 REMOTE_FIND_TIMEOUT = float(os.environ.get('GRAPHITE_REMOTE_FIND_TIMEOUT', '30'))           # Timeout for metric find requests
 REMOTE_FETCH_TIMEOUT = float(os.environ.get('GRAPHITE_REMOTE_FETCH_TIMEOUT', '60'))          # Timeout to fetch series data
-REMOTE_RETRY_DELAY = float(os.environ.get('GRAPHITE_REMOTE_RETRY_DELAY', '0'))           # Time before retrying a failed remote webapp
+REMOTE_RETRY_DELAY = float(0)          # Time before retrying a failed remote webapp. should stay 0 so we always retry metrictank because it is authorative. see https://github.com/raintank/graphite-mt/pull/11
 
 # Try to detect when a cluster server is localhost and don't forward queries
 REMOTE_EXCLUDE_LOCAL = False

--- a/local_settings.py
+++ b/local_settings.py
@@ -121,7 +121,7 @@ POOL_WORKERS = int(os.environ.get('GRAPHITE_POOL_WORKERS', '1'))
 # These are timeout values (in seconds) for requests to remote webapps
 REMOTE_FIND_TIMEOUT = float(os.environ.get('GRAPHITE_REMOTE_FIND_TIMEOUT', '30'))           # Timeout for metric find requests
 REMOTE_FETCH_TIMEOUT = float(os.environ.get('GRAPHITE_REMOTE_FETCH_TIMEOUT', '60'))          # Timeout to fetch series data
-REMOTE_RETRY_DELAY = float(os.environ.get('GRAPHITE_REMOTE_RETRY_DELAY', '10'))           # Time before retrying a failed remote webapp
+REMOTE_RETRY_DELAY = float(os.environ.get('GRAPHITE_REMOTE_RETRY_DELAY', '0'))           # Time before retrying a failed remote webapp
 
 # Try to detect when a cluster server is localhost and don't forward queries
 REMOTE_EXCLUDE_LOCAL = False


### PR DESCRIPTION
we should always keeps retrying CLUSTER_SERVERS
to get accurate status codes.

When MT returns 503's graphite should always be returning 503's.
But what was happening is that graphite would just kick the MT out of the
pool and falsely return empty 200 OK's.

This fixes that. (confirmed fix in metrictank docker-cluster stack.
curled requests in loops, all 503's now)