### PR TITLE
build 1.1.5-ge4ccaa21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: build-graphite
 	docker build -t ${PROJECT}/${APP}:${VERSION} .
 
 build-graphite:
-	docker run --rm -v $(shell pwd)/build-graphite:/opt/graphite -v $(shell pwd)/graphite:/opt/build -e VERSION=${e4ccaa2104499bcc8a39a5479b57a4af898bf9a4} ubuntu:xenial /opt/build/build.sh
+	docker run --rm -v $(shell pwd)/build-graphite:/opt/graphite -v $(shell pwd)/graphite:/opt/build -e VERSION=e4ccaa2104499bcc8a39a5479b57a4af898bf9a4 ubuntu:xenial /opt/build/build.sh
 
 push: build
 	docker push ${PROJECT}/${APP}:${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.1.5
+VERSION=1.1.5-ge4ccaa21
 PROJECT=raintank
 APP=graphite-mt
 TAG_LATEST=0
@@ -12,7 +12,7 @@ build: build-graphite
 	docker build -t ${PROJECT}/${APP}:${VERSION} .
 
 build-graphite:
-	docker run --rm -v $(shell pwd)/build-graphite:/opt/graphite -v $(shell pwd)/graphite:/opt/build -e VERSION=${VERSION} ubuntu:xenial /opt/build/build.sh
+	docker run --rm -v $(shell pwd)/build-graphite:/opt/graphite -v $(shell pwd)/graphite:/opt/build -e VERSION=${e4ccaa2104499bcc8a39a5479b57a4af898bf9a4} ubuntu:xenial /opt/build/build.sh
 
 push: build
 	docker push ${PROJECT}/${APP}:${VERSION}


### PR DESCRIPTION
not the cleanest.
note that Graphite's release tags are not part of master. they are separate branches.

in reality:
```
git describe --tags                                                                                                                                                     ⏎
1.1.0-292-ge4ccaa21
```

but that's just needlessly confusing, so i faked the tag. but that means we can't pass it to the build script