### PR TITLE
Allow user to enforce input validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # VERSION is using this naming scheme: <our version>-<graphite version>
 #
-# our version:      a number to identify the graphite-mt image, it should be increased every time anything
-#                   in this repo gets modified
-# graphite version: the version of the graphite image that's used. preferrably the tag if there is one, 
+# our version:      a number to identify the graphite-mt image, it should be increased
+#                   every time anything in this repo gets modified
+# graphite version: the version of graphite that's used. preferrably the tag if there is one,
 #                   otherwise the commit hash
 #
 VERSION=1-ge4ccaa21

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-VERSION=1.1.5-ge4ccaa21
+# VERSION is using this naming scheme: <our version>-<graphite version>
+#
+# our version:      a number to identify the graphite-mt image, it should be increased every time anything
+#                   in this repo gets modified
+# graphite version: the version of the graphite image that's used. preferrably the tag if there is one, 
+#                   otherwise the commit hash
+#
+VERSION=1-ge4ccaa21
 PROJECT=raintank
 APP=graphite-mt
 TAG_LATEST=0

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
-# VERSION is using this naming scheme: <our version>-<graphite version>
-#
-# our version:      a number to identify the graphite-mt image, it should be increased
-#                   every time anything in this repo gets modified
-# graphite version: the version of graphite that's used. preferrably the tag if there is one,
-#                   otherwise the commit hash
-#
-VERSION=1-ge4ccaa21
+IMAGE_VERSION=1
+GRAPHITE_VERSION=e4ccaa21
+VERSION=${IMAGE_VERSION}-${GRAPHITE_VERSION}
 PROJECT=raintank
 APP=graphite-mt
 TAG_LATEST=0
@@ -19,7 +14,7 @@ build: build-graphite
 	docker build -t ${PROJECT}/${APP}:${VERSION} .
 
 build-graphite:
-	docker run --rm -v $(shell pwd)/build-graphite:/opt/graphite -v $(shell pwd)/graphite:/opt/build -e VERSION=e4ccaa2104499bcc8a39a5479b57a4af898bf9a4 ubuntu:xenial /opt/build/build.sh
+	docker run --rm -v $(shell pwd)/build-graphite:/opt/graphite -v $(shell pwd)/graphite:/opt/build -e VERSION=${GRAPHITE_VERSION} ubuntu:xenial /opt/build/build.sh
 
 push: build
 	docker push ${PROJECT}/${APP}:${VERSION}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ git clone https://github.com/raintank/graphite-mt.git
 ```
 Then `cd` into the directory and run
 ```
-make build VERSION=1.0.2
+make build
 ```
 
+## Versioning
+
+We're using this naming scheme: `graphite-mt:<our version>-<graphite version>`
+
+`our version`:      a number to identify the graphite-mt image, it should be increased
+                    every time anything in this repo gets modified
+`graphite version`: the version of graphite that's used. preferrably the tag if there is one,
+                    otherwise the commit hash
+
+These two version numbers get defined in the `Makefile`.
+Valid image versions are for example: `1-1.1.5`, `2-e4ccaa21`, `3-e4ccaa21`

--- a/local_settings.py
+++ b/local_settings.py
@@ -94,6 +94,8 @@ TAGDB_HTTP_USER = os.environ.get('GRAPHITE_TAGDB_HTTP_USER', '')
 TAGDB_HTTP_PASSWORD = os.environ.get('GRAPHITE_TAGDB_HTTP_PASSWORD', '')
 TAGDB_HTTP_AUTOCOMPLETE = os.environ.get('GRAPHITE_TAGDB_HTTP_AUTOCOMPLETE', 'false').lower() in ['1','true','yes']
 
+ENFORCE_INPUT_VALIDATION = os.environ.get('GRAPHITE_ENFORCE_INPUT_VALIDATION', 'false').lower() in ['1','true','yes']
+
 # Creates a pool of worker threads to which tasks can be dispatched. This makes
 # sense if there are multiple CLUSTER_SERVERS because then the communication
 # with them can be parallelized


### PR DESCRIPTION
unfortunately this breaks with the previous naming scheme of (`1.1.5-ge4ccaa21`), but after discussing on slack i think this scheme makes more sense, because it allows us to bump the version number no matter which attribute of the build has changed (graphite version or graphite-mt version)