### PR TITLE
Configurable metric names

### DIFF
--- a/graphite/build.sh
+++ b/graphite/build.sh
@@ -17,10 +17,9 @@ fi
 
 virtualenv /opt/graphite
 /opt/graphite/bin/pip install --no-binary=:all: https://github.com/graphite-project/graphite-web/tarball/${VERSION}
-#/opt/graphite/bin/pip install --no-binary=:all: https://github.com/graphite-project/whisper/tarball/${VERSION}
 /opt/graphite/bin/pip install blist
 /opt/graphite/bin/pip install scandir
-/opt/graphite/bin/pip install --no-binary=:all: https://github.com/django-statsd/django-statsd/tarball/master
+/opt/graphite/bin/pip install --no-binary=:all: https://github.com/grafana/django-statsd/tarball/allow_overrides_for_metric_names_by_request_path
 
 cp /opt/graphite/conf/graphite.wsgi.example /opt/graphite/conf/graphite.wsgi
 

--- a/graphite/build.sh
+++ b/graphite/build.sh
@@ -19,7 +19,7 @@ virtualenv /opt/graphite
 /opt/graphite/bin/pip install --no-binary=:all: https://github.com/graphite-project/graphite-web/tarball/${VERSION}
 /opt/graphite/bin/pip install blist
 /opt/graphite/bin/pip install scandir
-/opt/graphite/bin/pip install --no-binary=:all: https://github.com/grafana/django-statsd/tarball/allow_overrides_for_metric_names_by_request_path
+/opt/graphite/bin/pip install --no-binary=:all: https://github.com/grafana/django-statsd/tarball/master
 
 cp /opt/graphite/conf/graphite.wsgi.example /opt/graphite/conf/graphite.wsgi
 

--- a/local_settings.py
+++ b/local_settings.py
@@ -177,3 +177,15 @@ if STATSD_HOST != '':
         pass
     else:
         MIDDLEWARE_CLASSES = MIDDLEWARE
+
+
+STATSD_METRIC_NAME_OVERRIDES = {
+    '/render': {
+        'module': 'graphite.render.views',
+        'name': 'renderView',
+    },
+    '/metrics/find': {
+        'module': 'graphite.metrics.views',
+        'name': 'find_view',
+    }
+}


### PR DESCRIPTION
This fixes the metric names which are by default auto-generated by `django-statsd`. Since graphite is now using decorators on view functions the metric names end up having the name of the decorator, which isn't what we want. 

To fix that issue this PR copies the code of `django-statsd` into `graphite/django-statsd` and then modifies the function `GraphiteRequestTimingMiddleware.process_view()` in `graphite/django-statsd/django_statsd/middleware.py` so that the metric names can be defined based on the request path. Then it also modifies `local_settings.py` and adds mappings for the `/metrics/find` and `/render` request paths. 

I deployed the resulting image in my QA instance, and we're now seeing metrics from graphite again:
https://ops.grafana.net/d/4KFv9v5ik/hosted-metrics-render-requests?orgId=1&fullscreen&edit&panelId=3&var-datasource=raintankPOC&var-environment=qa-us-central1-1-replaytest1&from=1583970223603&to=1583970775740

Fixes https://github.com/grafana/metrictank-ops/issues/577