### PR TITLE
sane default make behavior, always clean when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: build
 clean:
 	docker run --rm -v $(shell pwd)/:/opt/graphite ubuntu:xenial rm -rf /opt/graphite/build-graphite
 
-build: build-graphite
+build: clean build-graphite
 	docker build -t ${PROJECT}/${APP}:${VERSION} .
 
 build-graphite:
@@ -23,4 +23,4 @@ ifeq ($(TAG_LATEST), 1)
 	docker push ${PROJECT}/${APP}:latest
 endif
 
-.PHONY: all build push
+.PHONY: all

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ git clone https://github.com/raintank/graphite-mt.git
 ```
 Then `cd` into the directory and run
 ```
-make build
+make
 ```
 
 ## Versioning


### PR DESCRIPTION
as we found out in a recent incident, one _must_ run make clean first,
otherwise resulting builds will be invalid.
