### PR TITLE
Add renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "github>grafana/grafana-renovate-config//presets/base"
+  ],
+  "ignorePresets": [
+    "github>grafana/grafana-renovate-config//presets/automerge"
+  ]
+}


### PR DESCRIPTION
The repo is already onboarded to Grafana self-hosted renovate. This PR only adds a base config. We can iterate on the details later.