### PR TITLE
chore: migrate to docker-build-push-image action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,14 @@ jobs:
         run: bash graphite/test.sh
 
       - name: Push image
-        uses: grafana/shared-workflows/actions/push-to-gar-docker@99afc12c9af11a4a8b89178197787e50b59d07f5 # push-to-gar-docker-v0.3.1
+        uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
         with:
           push: ${{ github.ref_name == 'master' }}
+          registries: gar
           tags: |-
             ${{ env.DOCKER_TAG }}
             type=raw,value=latest,enable=${{ github.ref_name == 'master' }}
-          image_name: "graphite-mt"
+          gar-image: "graphite-mt"
           context: "."
           file: "./Dockerfile"
-          environment: "prod"
+          gar-environment: "prod"


### PR DESCRIPTION
## Summary

Replaces the deleted [`grafana/shared-workflows/actions/push-to-gar-docker`](https://github.com/grafana/shared-workflows/tree/main/actions/push-to-gar-docker) with its successor [`grafana/shared-workflows/actions/docker-build-push-image`](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image) in [.github/workflows/build.yml](.github/workflows/build.yml).

The previous action was deleted from `grafana/shared-workflows` on 2026-04-21 ([grafana/shared-workflows#1879](https://github.com/grafana/shared-workflows/pull/1879)). Our pinned SHA still resolves and runs for now, but the action is unsupported and would block the next time we bump the pin.

Follows the same migration done in [grafana/transmog#2654](https://github.com/grafana/transmog/pull/2654).

## Input mapping

| Old (`push-to-gar-docker`) | New (`docker-build-push-image`) |
|---|---|
| `image_name` | `gar-image` |
| `environment` | `gar-environment` |
| _(implicit)_ | `registries: gar` (new, required) |
| `push`, `tags`, `context`, `file` | unchanged |

Verified against the [action.yaml](https://github.com/grafana/shared-workflows/blob/34f27887c37cafe70d34af57dfc86b468a31b8c4/actions/docker-build-push-image/action.yaml) at the pinned SHA `34f27887` (docker-build-push-image/v0.3.3).

## Behavior preserved

- Image is only pushed on `master` (`push: ${{ github.ref_name == 'master' }}`).
- Always pushed to the prod registry: `us-docker.pkg.dev/grafanalabs-global/docker-graphite-mt-prod/graphite-mt:<tag>`.

## Behavior changes (from the new action's defaults)

- GHA layer caching is enabled by default (`cache-from: type=gha`, `cache-to: type=gha,mode=max`). First post-merge build warms the cache; subsequent rebuilds should be faster.
- QEMU is set up unconditionally (~5s overhead; no-op for our single-arch native build).
- Job-end cleanup of the GAR credentials file (defense-in-depth).

## Test plan

- [x] Verified the new action's input names against its `action.yaml` at the pinned SHA `34f27887` (docker-build-push-image/v0.3.3).
- [ ] CI on this PR exercises the build path (no push, since `push` is gated on `master`).
- [ ] After merge, the post-merge build on `master` will exercise the push path against `docker-graphite-mt-prod`.

Coded with Claude Opus 4.7.