### PR TITLE
fix(cve): upgrade base-image packages flagged by scanners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
 RUN apt-get update && \
-    apt-get install -y --only-upgrade libgnutls30 && \
+    apt-get install -y --only-upgrade libgnutls30 gzip tar \
+      libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 \
+      libncurses6 libncursesw6 libtinfo6 ncurses-base ncurses-bin \
+      libpam-modules libpam-modules-bin libpam-runtime libpam0g && \
     apt-get -y install python3.10 apache2 curl libcairo2 libffi8 libpython3.10 tzdata && \
     rm -rf /var/lib/apt/lists/* && \
     # we don't need the snakeoil certs in our setup, and they are flagged as insecure


### PR DESCRIPTION
Extends the existing `--only-upgrade` list with packages that ship preinstalled in the `ubuntu:jammy` base image and are therefore never upgraded by our `apt-get install` step: gzip, tar, krb5 libs, ncurses, and PAM.

Together with a fresh `ubuntu:jammy` pull at build time, this clears all fixable CVEs reported by grype and trivy (previously 1 High + ~150 fixable Medium/Low). Remaining findings have no fix available from Ubuntu.

`graphite/test.sh` passes (7/7).